### PR TITLE
Explicity require python3

### DIFF
--- a/maildir2mbox.py
+++ b/maildir2mbox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python 
+#!/usr/bin/env python3 
 # -*- coding: utf-8 -*-
 u"""
 Frédéric Grosshans, 19 January 2012


### PR DESCRIPTION
Debian still links `/usr/bin/python` to `python2`, which might be confusing for some.